### PR TITLE
 - Replace Rmagick with minimagick

### DIFF
--- a/lib/zxing/ffi/common/greyscale_luminance_source.rb
+++ b/lib/zxing/ffi/common/greyscale_luminance_source.rb
@@ -19,12 +19,4 @@ class ZXing::FFI::Common::GreyscaleLuminanceSource < ZXing::FFI::LuminanceSource
                                                            width,
                                                            height)
   end
-  def image
-    Magick::Image.constitute(width,
-                             height, 
-                             "I",
-                             matrix.get_array_of_char(0, width*height).map{|v|
-                               v << 8
-                             })
-  end
 end

--- a/lib/zxing/rmagick/image.rb
+++ b/lib/zxing/rmagick/image.rb
@@ -1,9 +1,4 @@
-begin
-  # Support both newer 'rmagick' require and deprecated 'RMagick' require:
-  require 'rmagick'
-rescue LoadError => e
-  require 'RMagick'
-end
+require 'mini_magick'
 
 module ZXing; end
 module ZXing::RMagick; end
@@ -13,63 +8,7 @@ class ZXing::RMagick::Image
   LuminanceSource = ZXing::FFI::Common::GreyscaleLuminanceSource
 
   def self.read argument
-    img = nil
-
-    if argument.is_a? String
-      if argument.encoding.name == Encoding.aliases['BINARY']
-        begin
-          img = Magick::Image.from_blob(argument)[0]
-        rescue Exception => e
-          # Because 'BINARY' is just an alias for ASCII-8BIT, if treating the
-          # argument as image blob failed, we should continue on and try treat
-          # the argument like a regular string.
-        end
-      end
-    end
-
-    if img.nil?
-      require 'uri'
-      require 'pathname'
-
-      uri = URI.parse(argument.respond_to?(:path) ? argument.path : argument.to_s)
-
-      if uri.scheme.nil?
-        uri.scheme = "file"
-        uri.path = Pathname.new(uri.path).realpath.to_s
-      end
-
-      begin
-        img = case uri.scheme
-                when "file"; Magick::Image.read(uri.path)[0]
-                else; Magick::Image.from_blob(fetch(uri).body)[0]
-              end
-      rescue Exception => e
-        raise ZXing::BadImageException.new e.message
-      end
-    end
-
-    # p Magick::Magick_version
-    # p img.colorspace
-    img.colorspace = Magick::RGBColorspace
-    # p img.colorspace
-
-    if false
-      (8..8).each do |j|
-        (8..8).each do |i|
-          p i,j
-          pixel = img.pixel_color(i,j)
-          r = pixel.red&0xff
-          g = pixel.green&0xff
-          b = pixel.blue&0xff
-          p ['%x'%r, '%x'%g, '%x'%b]
-          p [r, g, b]
-          p ((306 * (r) + 601 * (g) + 117 * (b) + (1 << 9)) >> 10)
-          p img.export_pixels_to_str(i, j, 1, 1, "I").ord
-          p "x"
-        end
-      end
-    end
-
+    img = MiniMagick::Image.open(argument)
     self.new img
   end
 
@@ -78,15 +17,20 @@ class ZXing::RMagick::Image
   end
 
   def width
-    @native.columns
+    @native[:width]
   end
 
   def height
-    @native.rows
+    @native[:height]
   end
 
   def gray
-    @native.export_pixels_to_str(0, 0, @native.columns, @native.rows, "I")
+    file_postfix = 'stream'
+    path = "#{@native.path}-#{file_postfix}"
+    MiniMagick::Tool::Stream.new do |s|
+      s.map 'i', '-storage-type', 'char', @native.path, path
+    end
+    File.read(path)
   end
 
   private

--- a/lib/zxing/version.rb
+++ b/lib/zxing/version.rb
@@ -1,5 +1,5 @@
 module ZXing
-  VERSION = "0.1.1" unless defined?(::ZXing::VERSION)
+  VERSION = "0.2.0" unless defined?(::ZXing::VERSION)
 
   VERSION_INFO = {}
   VERSION_INFO['warnings']              = []

--- a/test/test_zxing.rb
+++ b/test/test_zxing.rb
@@ -1,12 +1,13 @@
 require File.expand_path( File.dirname(__FILE__) + '/test_helper')
+require 'shoulda'
 require 'zxing'
 
 class ZXingTest < MiniTest::Test
-  context "A QR decoder singleton" do
+  describe "A QR decoder singleton" do
 
     class Foo < Struct.new(:v); def to_s; self.v; end; end
 
-    setup do
+    before do
       @decoder = ZXing
       @uri = "http://2d-code.co.uk/images/bbc-logo-in-qr-code.gif"
       @path = File.expand_path( File.dirname(__FILE__) + '/qrcode.png')
@@ -16,43 +17,29 @@ class ZXingTest < MiniTest::Test
       @path_result = "http://rubyflow.com"
     end
 
-    should "decode a URL" do
-      assert_equal @decoder.decode(@uri), @uri_result
-    end
-
-    should "decode a file path" do
+    it "decode a file path" do
       assert_equal @decoder.decode(@path), @path_result
     end
 
-    should "return nil if #decode fails" do
+    it "return nil if #decode fails" do
       assert_nil @decoder.decode(@google_logo)
     end
 
-    should "raise an exception if #decode! fails" do
+    it "raise an exception if #decode! fails" do
       assert_raises(ZXing::ReaderException,
                     ZXing::NotFoundException) { @decoder.decode!(@google_logo) }
     end
-
-    should "decode objects that respond to #path" do
-      assert_equal @decoder.decode(@file), @path_result
-    end
-
-    should "call #to_s to argument passed in as a last resort" do
-      assert_equal @decoder.decode(Foo.new(@path)), @path_result
-    end
   end
 
-  context "A QR decoder module" do
-    
-    setup do
+  describe "A QR decoder module" do
+    before do
       class SpyRing; include ZXing end
       @ring = SpyRing.new
     end
 
-    should "include #decode and #decode! into classes" do
+    it "include #decode and #decode! into classes" do
       assert @ring.method(:decode)
       assert @ring.method(:decode!)
     end
-
   end
 end

--- a/test/zxing/test_decodable.rb
+++ b/test/zxing/test_decodable.rb
@@ -15,23 +15,19 @@ class DecodableTest < MiniTest::Test
     def path; @path end
   end
 
-  context "A Decodable module" do
-    setup do
+  describe "A Decodable module" do
+    before do
       @file = File.open( File.expand_path( File.dirname(__FILE__) + '/../qrcode.png' ))
       @uri = URL.new "http://2d-code.co.uk/images/bbc-logo-in-qr-code.gif"
       @bad_uri = URL.new "http://google.com"
     end
 
-    should "provide #decode to decode the return value of #path" do
+    it "provide #decode to decode the return value of #path" do
       assert_equal @file.decode, ZXing.decode(@file.path)
-      assert_equal @uri.decode, ZXing.decode(@uri.path)
-      assert_nil @bad_uri.decode
     end
 
-    should "provide #decode! as well" do
+    it "provide #decode! as well" do
       assert_equal @file.decode!, ZXing.decode(@file.path)
-      assert_equal @uri.decode!, ZXing.decode(@uri.path)
-      assert_raises(ZXing::BadImageException) { @bad_uri.decode! }
     end
   end
 

--- a/zxing_cpp.gemspec
+++ b/zxing_cpp.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'shoulda', '~> 3.5'
 
-  s.add_dependency 'ffi', '~> 1.1'
-  s.add_dependency 'rmagick', '~> 2.13'
+  s.add_dependency 'ffi', '~> 1.9.25'
+  s.add_dependency 'mini_magick', '~> 4.9'
 end


### PR DESCRIPTION
 - Only accept file for Decode
 - Remove tests related to other input types

Possibly breaks some library specifics, for example running ``` zxd -q 'FILE_PATH' ``` is not working.

I am aslo doing some preprocessing before sending the file into this lib for qr code detection.
example:
```
    image = MiniMagick::Image.open(path)
    image.colorspace "Gray"
    image.threshold "30%"
    image.resize '500x'
    image.write "out.jpg"

    result = ZXing.decode! "out.jpg"
```
This will grayscale the image at a lower threshold and then resize it before passing it into zxing for decoding.